### PR TITLE
add Mages MPK support

### DIFF
--- a/GAMELIST.htm
+++ b/GAMELIST.htm
@@ -3154,6 +3154,15 @@ var games = [
   info: 'About 90 files (mostly audio) can\'t be extracted because of unknown file names. I fast forwarded through every route, logging which files are loaded, and the game doesn\'t seem to ever use them.',
   fmt: {archives: ['dat'], gfx: ['tlg'], audio: ['ogg'], video: ['avi']},
   args: ['--dec=whale/dat --file-names=etc/noraneko.lst']},
+  
+{ dev: '5pb.',
+  date: '2016-04-28',
+  title: 'Chaos;Child',
+  title_orig: 'ChäoS;Child',
+  vndb: 14018,
+  info: 'PC version',
+  fmt: {gfx: ['dds', 'png'], audio: ['ogg'], video: ['bk2'], misc: ['scx']},
+  args: ['--dec=mages/mpk']},
 
 ];
 </script>

--- a/src/dec/mages/mpk_archive_decoder.cc
+++ b/src/dec/mages/mpk_archive_decoder.cc
@@ -1,0 +1,60 @@
+#include "dec/mages/mpk_archive_decoder.h"
+#include "algo/range.h"
+
+using namespace au;
+using namespace au::dec::mages;
+
+static const bstr magic = "MPK\0"_b;
+
+bool MpkArchiveDecoder::is_recognized_impl(io::File &input_file) const
+{
+    return input_file.stream.seek(0).read(magic.size()) == magic;
+}
+
+std::unique_ptr<dec::ArchiveMeta> MpkArchiveDecoder::read_meta_impl(
+    const Logger &logger, io::File &input_file) const
+{
+    input_file.stream.seek(magic.size());
+    // only known version is 02.00
+    const auto version_minor = input_file.stream.read_le<u16>();
+    const auto version_major = input_file.stream.read_le<u16>();
+
+    auto meta = std::make_unique<ArchiveMeta>();
+
+    const auto file_count = input_file.stream.read_le<u32>();
+    input_file.stream.seek(64); // unused header fields
+    for (const auto i : algo::range(file_count))
+    {
+        auto entry = std::make_unique<PlainArchiveEntry>();
+        // 32-bit unknown field (always 0), then 32-bit index
+        input_file.stream.skip(8);
+        entry->offset = input_file.stream.read_le<u64>();
+        entry->size = input_file.stream.read_le<u64>();
+        input_file.stream.skip(8); // duplicate of size, purpose unknown
+        entry->path = input_file.stream.read_to_zero(224).str();
+
+        // file_count appears to include some blank alignment entries
+        if (entry->offset != 0 && entry->size != 0)
+            meta->entries.push_back(std::move(entry));
+    }
+
+    return meta;
+}
+
+std::unique_ptr<io::File> MpkArchiveDecoder::read_file_impl(
+    const Logger &logger,
+    io::File &input_file,
+    const dec::ArchiveMeta &m,
+    const dec::ArchiveEntry &e) const
+{
+    const auto entry = static_cast<const PlainArchiveEntry*>(&e);
+    const auto data = input_file.stream.seek(entry->offset).read(entry->size);
+    return std::make_unique<io::File>(entry->path, data);
+}
+
+std::vector<std::string> MpkArchiveDecoder::get_linked_formats() const
+{
+    return {"microsoft/dds", "png/png"};
+}
+
+static auto _ = dec::register_decoder<MpkArchiveDecoder>("mages/mpk");

--- a/src/dec/mages/mpk_archive_decoder.h
+++ b/src/dec/mages/mpk_archive_decoder.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "dec/base_archive_decoder.h"
+
+namespace au {
+namespace dec {
+namespace mages {
+
+    class MpkArchiveDecoder final : public BaseArchiveDecoder
+    {
+    public:
+        std::vector<std::string> get_linked_formats() const override;
+
+    protected:
+        bool is_recognized_impl(io::File &input_file) const override;
+
+        std::unique_ptr<ArchiveMeta> read_meta_impl(
+            const Logger &logger,
+            io::File &input_file) const override;
+
+        std::unique_ptr<io::File> read_file_impl(
+            const Logger &logger,
+            io::File &input_file,
+            const ArchiveMeta &m,
+            const ArchiveEntry &e) const override;
+    };
+
+} } }

--- a/tests/dec/mages/mpk_archive_decoder_test.cc
+++ b/tests/dec/mages/mpk_archive_decoder_test.cc
@@ -1,0 +1,57 @@
+#include "dec/mages/mpk_archive_decoder.h"
+#include "test_support/catch.h"
+#include "test_support/decoder_support.h"
+#include "test_support/file_support.h"
+
+using namespace au;
+using namespace au::dec::mages;
+
+static void write_toc_entry(
+    io::BaseByteStream &output_stream, const u32 id, const u64 offset,
+    const u64 size, const std::string &path)
+{
+    output_stream.write_le<u32>(0);
+    output_stream.write_le<u32>(id);
+    output_stream.write_le<u64>(offset);
+    output_stream.write_le<u64>(size);
+    output_stream.write_le<u64>(size);
+    output_stream.write_zero_padded(path, 224);
+}
+
+TEST_CASE("MAGES. MPK archives archives", "[dec]")
+{
+    const std::vector<std::shared_ptr<io::File>> expected_files
+    {
+        tests::stub_file("WIN\\test1.txt", "hello"_b),
+        tests::stub_file("test2.txt", "world"_b),
+    };
+
+    auto output_file = std::make_unique<io::File>("mini.mpk", ""_b);
+    output_file->stream.write("MPK\0"_b);
+    output_file->stream.write_le<u16>(0);
+    output_file->stream.write_le<u16>(2);
+    // file count may go over actual file count (but never outside of TOC)
+    output_file->stream.write_le<u32>(expected_files.size() + 2);
+    output_file->stream.write(bstr(52));
+
+    for (size_t i = 0; i < expected_files.size(); i++)
+    {
+        if (expected_files[i]->path.str().empty()) continue;
+        // note: assumes TOC and every test file are <= 2KB each
+        // IDs needn't be sequential, hence the random numbers
+        write_toc_entry(output_file->stream, std::rand(), (i + 1) * 2048,
+             expected_files[i]->stream.size(),
+             expected_files[i]->path.str());
+    }
+    for (size_t i = 0; i < expected_files.size(); i++)
+    {
+        output_file->stream.write(
+            bstr(((i + 1) * 2048) - output_file->stream.pos()));
+        auto data = expected_files[i]->stream.seek(0).read_to_eof();
+        output_file->stream.write(data);
+    }
+
+    const auto decoder = MpkArchiveDecoder();
+    const auto actual_files = tests::unpack(decoder, *output_file);
+    tests::compare_files(actual_files, expected_files, true);
+}


### PR DESCRIPTION
As used in the recently released PC port of Chaos;Child, and most likely also the soon-to-be-released PC port of Steins;Gate Zero.

Most of this time was spent setting up my build environment and worrying about consistency, I swear!