### PR TITLE
Fix building on OSX

### DIFF
--- a/src/algo/call_stack_keeper.cc
+++ b/src/algo/call_stack_keeper.cc
@@ -1,5 +1,6 @@
 #include "algo/call_stack_keeper.h"
 #include "err.h"
+#include <string>
 
 using namespace au::algo;
 
@@ -29,8 +30,9 @@ bool CallStackKeeper::recursion_limit_reached() const
 
 void CallStackKeeper::recurse(const std::function<void()> &action)
 {
+    const std::string recursion_error = std::string("Recursion limit reached");
     if (recursion_limit_reached())
-        throw err::GeneralError("Recursion limit reached");
+        throw err::GeneralError(recursion_error);
     p->depth++;
     try
     {

--- a/src/dec/almond_collective/pac3_archive_decoder.cc
+++ b/src/dec/almond_collective/pac3_archive_decoder.cc
@@ -3,6 +3,7 @@
 #include "algo/locale.h"
 #include "algo/range.h"
 #include "io/memory_byte_stream.h"
+#include <array>
 
 using namespace au;
 using namespace au::dec::almond_collective;

--- a/src/dec/dogenzaka/a_file_decoder.cc
+++ b/src/dec/dogenzaka/a_file_decoder.cc
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include "algo/crypt/sha1.h"
 #include "algo/range.h"
+#include <array>
 
 using namespace au;
 using namespace au::dec::dogenzaka;

--- a/src/dec/entis/eri_image_decoder.cc
+++ b/src/dec/entis/eri_image_decoder.cc
@@ -12,6 +12,7 @@
 #include "dec/entis/image/lossless.h"
 #include "err.h"
 #include "virtual_file_system.h"
+#include <cmath>
 
 using namespace au;
 using namespace au::dec::entis;
@@ -41,8 +42,8 @@ static image::EriHeader read_header(
 
     const s32 width         = input_stream.read_le<u32>();
     const s32 height        = input_stream.read_le<u32>();
-    header.width            = std::abs(width);
-    header.height           = std::abs(height);
+    header.width            = std::fabs(width);
+    header.height           = std::fabs(height);
     header.flip             = height > 0;
     header.bit_depth        = input_stream.read_le<u32>();
     header.clipped_pixel    = input_stream.read_le<u32>();

--- a/src/dec/fc01/mcg_image_decoder.cc
+++ b/src/dec/fc01/mcg_image_decoder.cc
@@ -6,6 +6,7 @@
 #include "dec/fc01/common/mrg_decryptor.h"
 #include "dec/fc01/common/util.h"
 #include "err.h"
+#include <cmath>
 
 using namespace au;
 using namespace au::dec::fc01;
@@ -35,9 +36,9 @@ static bstr transform_v200(
         int p00 = planes[i][pos];
         int p10 = planes[i][pos + width] - p00;
         int p01 = planes[i][pos + 1] - p00;
-        p00 = std::abs(p01 + p10);
-        p01 = std::abs(p01);
-        p10 = std::abs(p10);
+        p00 = std::fabs(p01 + p10);
+        p01 = std::fabs(p01);
+        p10 = std::fabs(p10);
         s8 p11a;
         if (p00 >= p01 && p10 >= p01)
             p11a = planes[i][pos + width];

--- a/src/dec/microsoft/bmp_image_decoder.cc
+++ b/src/dec/microsoft/bmp_image_decoder.cc
@@ -4,6 +4,7 @@
 #include "err.h"
 #include "io/memory_byte_stream.h"
 #include "io/msb_bit_stream.h"
+#include <cmath>
 
 using namespace au;
 using namespace au::dec::microsoft;
@@ -74,7 +75,7 @@ static Header read_header(io::BaseByteStream &input_stream)
         h.palette_size = header_stream.read_le<u32>();
         h.important_colors = header_stream.read_le<u32>();
     }
-    h.height = std::abs(height);
+    h.height = std::fabs(height);
     h.flip = height > 0;
 
     if (h.depth <= 8 && !h.palette_size)


### PR DESCRIPTION
This doesn't fix linking as I'm not sure how to do that with cmake.

```
Scanning dependencies of target arc_unpacker
[ 57%] Building CXX object CMakeFiles/arc_unpacker.dir/src/main.cc.o
[ 57%] Linking CXX executable arc_unpacker
clang: warning: argument unused during compilation: '-pthread'
Undefined symbols for architecture x86_64:
  "_iconv", referenced from:
      convert_locale(au::bstr const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allo
cator<char> > const&) in locale.cc.o
  "_iconv_close", referenced from:
      convert_locale(au::bstr const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allo
cator<char> > const&) in locale.cc.o
  "_iconv_open", referenced from:
      convert_locale(au::bstr const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allo
cator<char> > const&) in locale.cc.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [arc_unpacker] Error 1
make[1]: *** [CMakeFiles/arc_unpacker.dir/all] Error 2
make: *** [all] Error 2
```

I haven't tested it on other systems (linux or windows).
