### PR TITLE
Fix file_byte_stream read-write permission

### DIFF
--- a/src/io/file_byte_stream.cc
+++ b/src/io/file_byte_stream.cc
@@ -64,7 +64,7 @@ struct FileByteStream::Priv final
         {
             fd = std::fopen(
                 path.c_str(),
-                mode == FileMode::Write ? "w+b" : "r+b");
+                mode == FileMode::Write ? "w+b" : "rb");
             if (!fd)
                 throw err::FileNotFoundError("Could not open " + path.str());
         }


### PR DESCRIPTION
Fix file_byte_stream so that read-only files can be read with read-only permission "rb" instead of read-write permission "r+b". Otherwise, read-only files are not read.