### PR TITLE
Add support for Ushinawareta Mirai o Motomete xp3 extraction

### DIFF
--- a/GAMELIST.js
+++ b/GAMELIST.js
@@ -3535,4 +3535,12 @@ var games = [
   fmt: {archives: ['dsk'], gfx: ['kg'], audio: ['ogg', 'wav']},
   args: ['--dec=abogado/dsk', '--dec=abogado/v']},
 
+{ dev: 'Trumple',
+  date: '2010-11-26',
+  title: 'Ushinawareta Mirai o Motomete',
+  title_orig: '失われた未来を求めて',
+  vndb: 4880,
+  fmt: {archives: ['xp3'], gfx: ['png'], audio: ['ogg']},
+  args: ['--dec=kirikiri/xp3 --plugin=waremete']},
+
 ];

--- a/src/dec/kirikiri/xp3_archive_decoder_plugins.cc
+++ b/src/dec/kirikiri/xp3_archive_decoder_plugins.cc
@@ -150,6 +150,11 @@ Xp3ArchiveDecoder::Xp3ArchiveDecoder()
             0x190, 0x4A7, {1,0,2}, {2,0,7,3,5,1,4,6}, {2,1,0,5,4,3},
             read_etc_file("karakara.dat")));
 
+    plugin_manager.add(
+        "waremete", "Ushinawareta Mirai o Motomete",
+        create_cxdec_plugin(
+            0x23C, 0x60F, {2,0,1}, {1,5,0,3,2,7,6,4}, {4,5,2,1,0,3}));
+
     add_arg_parser_decorator(
         plugin_manager.create_arg_parser_decorator(
             "Selects XP3 decryption routine."));


### PR DESCRIPTION
The xp3 archives of Ushinawareta Mirai o Motomete (or WareMete for short) use cxdec tpm.
This pull request adds a plugin that allows extraction of those archives and adds an associated entry to the game list.