### PR TITLE
dec/kaguya: apply offset to images

### DIFF
--- a/src/dec/kaguya/ap2_image_decoder.cc
+++ b/src/dec/kaguya/ap2_image_decoder.cc
@@ -32,8 +32,8 @@ res::Image Ap2ImageDecoder::decode_impl(
     const Logger &logger, io::File &input_file) const
 {
     input_file.stream.seek(magic.size());
-    const auto x = input_file.stream.read_le<u32>();
-    const auto y = input_file.stream.read_le<u32>();
+    const auto x_offset = input_file.stream.read_le<u32>();
+    const auto y_offset = input_file.stream.read_le<u32>();
     const auto width = input_file.stream.read_le<u32>();
     const auto height = input_file.stream.read_le<u32>();
     const auto depth = input_file.stream.read_le<u32>();
@@ -41,7 +41,8 @@ res::Image Ap2ImageDecoder::decode_impl(
         throw err::UnsupportedBitDepthError(depth);
     const auto data = input_file.stream.read_to_eof();
     return res::Image(width, height, data, res::PixelFormat::BGRA8888)
-        .flip_vertically();
+        .flip_vertically()
+        .offset(x_offset, y_offset);
 }
 
 static auto _ = dec::register_decoder<Ap2ImageDecoder>("kaguya/ap2");

--- a/src/dec/kaguya/ap3_image_decoder.cc
+++ b/src/dec/kaguya/ap3_image_decoder.cc
@@ -32,8 +32,8 @@ res::Image Ap3ImageDecoder::decode_impl(
     const Logger &logger, io::File &input_file) const
 {
     input_file.stream.seek(magic.size());
-    const auto x = input_file.stream.read_le<u32>();
-    const auto y = input_file.stream.read_le<u32>();
+    const auto x_offset = input_file.stream.read_le<u32>();
+    const auto y_offset = input_file.stream.read_le<u32>();
     const auto width = input_file.stream.read_le<u32>();
     const auto height = input_file.stream.read_le<u32>();
     const auto depth = input_file.stream.read_le<u32>();
@@ -41,7 +41,8 @@ res::Image Ap3ImageDecoder::decode_impl(
         throw err::UnsupportedBitDepthError(depth);
     const auto data = input_file.stream.read_to_eof();
     return res::Image(width, height, data, res::PixelFormat::BGR888)
-        .flip_vertically();
+        .flip_vertically()
+        .offset(x_offset, y_offset);
 }
 
 static auto _ = dec::register_decoder<Ap3ImageDecoder>("kaguya/ap3");

--- a/tests/dec/kaguya/an20_image_archive_decoder_test.cc
+++ b/tests/dec/kaguya/an20_image_archive_decoder_test.cc
@@ -63,8 +63,8 @@ TEST_CASE("Atelier Kaguya AN20 image archives", "[dec]")
     input_file.stream.write_le<u32>(expected_images.at(0).height());
     for (const auto &image : expected_images)
     {
-        input_file.stream.write_le<u32>('?');
-        input_file.stream.write_le<u32>('?');
+        input_file.stream.write_le<u32>(0);
+        input_file.stream.write_le<u32>(0);
         input_file.stream.write_le<u32>(image.width());
         input_file.stream.write_le<u32>(image.height());
         res::Image flipped_image(image);


### PR DESCRIPTION
Currently for kaguya image files and archives that are used for drawing over a specific part of the image only the replaced part is output without respecting the x/y offset that is needed to correctly overlay the images. I fixed this by using the res::Image::offset function to add the x/y offset as transparency. I also changed some of the involved variable names to better reflect their meaning. I only added this behaviour for the AN00/20/21 and AP2/3 file types since I do not have any files of the other types to test with.
As for automated testing I do not know what could be tested so I did not add any. I changed one existing test that used an incorrect offset so all tests pass now.
Please let me know if any changes are needed.