### PR TITLE
Added more support for G-Senjou No Maou

### DIFF
--- a/src/dec/kirikiri/xp3_archive_decoder_plugins.cc
+++ b/src/dec/kirikiri/xp3_archive_decoder_plugins.cc
@@ -126,6 +126,16 @@ Xp3ArchiveDecoder::Xp3ArchiveDecoder()
         }));
 
     plugin_manager.add(
+        "gsenjou", "G-Senjou No Maou",
+        create_simple_plugin([](bstr &data, u32 key)
+        {
+            key >>= 12;
+
+            for (int i = 5; i < data.size(); i++)
+                data[i] ^= key;
+        }));
+
+    plugin_manager.add(
         "fha", "Fate/Hollow Ataraxia",
         create_cxdec_plugin(
             0x143, 0x787, {0,1,2}, {0,1,2,3,4,5,6,7}, {0,1,2,3,4,5}));


### PR DESCRIPTION
Hello!
As described in this issue: https://github.com/vn-tools/arc_unpacker/issues/185
It seems that the voice version of G-Senjou No Maou Visual Novel seems to be xor'd.
So I've implemented a plugin for it, yet, there is still some problems...

The patch, patch2, voice xp3 package gives these errors:

```
[task 0] voice~.xp3: recognition finished with errors:
[task 0] voice~.xp3: Premature end of file
```

I assume this is because they might introduced some xp3 format variants or parsing is done in a wrong way in the newest version, but I'm not totally sure yet.

I'll push new/update the commit(s) if I find time to fix these packages extraction.