### PR TITLE
Fix build: add missing <stdexcept> import

### DIFF
--- a/src/algo/crypt/lcg.cc
+++ b/src/algo/crypt/lcg.cc
@@ -17,6 +17,7 @@
 
 #include "algo/crypt/lcg.h"
 #include <functional>
+#include <stdexcept>
 
 using namespace au;
 using namespace au::algo::crypt;


### PR DESCRIPTION
`std::logic_error` is used in this file, which resides in `<stdexcept>`, but was not imported before.

This caused the build to fail, see, e.g., https://hydra.nixos.org/build/141997371/log:

```console
[...]
build/source/src/algo/crypt/lcg.cc: In constructor 'au::algo::crypt::Lcg::Lcg(au::algo::crypt::LcgKind, au::u32)':
/build/source/src/algo/crypt/lcg.cc:70:24: error: 'logic_error' is not a member of 'std'
   70 |             throw std::logic_error("Unknown LCG kind");
      |                        ^~~~~~~~~~~
make[2]: *** [CMakeFiles/libau.dir/build.make:160: CMakeFiles/libau.dir/src/algo/crypt/lcg.cc.o] Error 1
[...]
```